### PR TITLE
Rather than extending a core class, let's just use #rcompact from a helper module

### DIFF
--- a/lib/spreadsheet/helpers.rb
+++ b/lib/spreadsheet/helpers.rb
@@ -1,11 +1,11 @@
-class Array
-  def rcompact
-    dup.rcompact!
-  end
-  def rcompact!
-    while !empty? && last.nil?
-      pop
+module Spreadsheet
+  module Helpers
+    def rcompact(array)
+      while !array.empty? && array.last.nil?
+        array.pop
+      end
+      array
     end
-    self
+    module_function :rcompact
   end
 end

--- a/lib/spreadsheet/row.rb
+++ b/lib/spreadsheet/row.rb
@@ -90,7 +90,7 @@ module Spreadsheet
     # This is primarily a helper-function for the writer classes.
     def formatted
       copy = dup
-      @formats.rcompact!
+      Helpers.rcompact(@formats)
       if copy.length < @formats.size
         copy.concat Array.new(@formats.size - copy.length)
       end
@@ -99,7 +99,7 @@ module Spreadsheet
     ##
     # Same as Row#size, but takes into account formatted empty cells
     def formatted_size
-      @formats.rcompact!
+      Helpers.rcompact(@formats)
       sz = size
       fs = @formats.size
       fs > sz ? fs : sz


### PR DESCRIPTION
It's better to leave core classes untouched unless the utility added is part of the expected benefit of including the library.
