### PR TITLE
Handling BigDecimals

### DIFF
--- a/lib/spreadsheet/excel/writer/worksheet.rb
+++ b/lib/spreadsheet/excel/writer/worksheet.rb
@@ -2,6 +2,7 @@ require 'stringio'
 require 'spreadsheet/excel/writer/biff8'
 require 'spreadsheet/excel/internals'
 require 'spreadsheet/excel/internals/biff8'
+require 'bigdecimal'
 
 module Spreadsheet
   module Excel


### PR DESCRIPTION
Based on the comments on https://groups.google.com/forum/?fromgroups#!topic/rubyspreadsheet/2sKXgIFPrKs and my own experience, we know that the gem doesn't handle BigDecimal precision.

Looking around, I found the fix introduced by the user 'valeriusjames' and it seems to be working fine. I don't know why he hasn't sent request, but I thing that is something to be considered...
