### PR TITLE
Work around to handle number formats that are being mistaken time format...

### DIFF
--- a/lib/spreadsheet/format.rb
+++ b/lib/spreadsheet/format.rb
@@ -104,7 +104,8 @@ module Spreadsheet
         :date         => Regexp.new(client("[YMD]", 'UTF-8')),
         :date_or_time => Regexp.new(client("[hmsYMD]", 'UTF-8')),
         :datetime     => Regexp.new(client("([YMD].*[HS])|([HS].*[YMD])", 'UTF-8')),
-        :time         => Regexp.new(client("[hms]", 'UTF-8'))
+        :time         => Regexp.new(client("[hms]", 'UTF-8')),
+        :number       => Regexp.new(client("[\#]", 'UTF-8'))
       }
       # Temp code to prevent merged formats in non-merged cells.
       @used_merge    = 0
@@ -178,22 +179,27 @@ module Spreadsheet
     ##
     # Is the cell formatted as a Date?
     def date?
-      !!@regexes[:date].match(@number_format.to_s)
+      !number? && !!@regexes[:date].match(@number_format.to_s)
     end
     ##
     # Is the cell formatted as a Date or Time?
     def date_or_time?
-      !!@regexes[:date_or_time].match(@number_format.to_s)
+      !number? && !!@regexes[:date_or_time].match(@number_format.to_s)
     end
     ##
     # Is the cell formatted as a DateTime?
     def datetime?
-      !!@regexes[:datetime].match(@number_format.to_s)
+      !number? && !!@regexes[:datetime].match(@number_format.to_s)
     end
     ##
     # Is the cell formatted as a Time?
     def time?
-      !!@regexes[:time].match(@number_format.to_s)
+      !number? && !!@regexes[:time].match(@number_format.to_s)
+    end
+    ##
+    # Is the cell formatted as a number?
+    def number?
+      !!@regexes[:number].match(@number_format.to_s)
     end
   end
 end

--- a/test/format.rb
+++ b/test/format.rb
@@ -19,6 +19,8 @@ module Spreadsheet
       assert_equal true, @format.date?
       @format.number_format = "YMD"
       assert_equal true, @format.date?
+      @format.number_format = "\\$#,##0.00_);[RED]\"($\"#,##0.00\\)"
+      assert_equal false, @format.date?
     end
     def test_date_or_time?
       assert_equal false, @format.date_or_time?
@@ -28,6 +30,8 @@ module Spreadsheet
       assert_equal true, @format.date_or_time?
       @format.number_format = "hmsYMD"
       assert_equal true, @format.date_or_time?
+      @format.number_format = "\\$#,##0.00_);[RED]\"($\"#,##0.00\\)"
+      assert_equal false, @format.date?
     end
     def test_datetime?
       assert_equal false, @format.datetime?
@@ -39,6 +43,8 @@ module Spreadsheet
       assert_equal false, @format.datetime?
       @format.number_format = "HSYMD"
       assert_equal true, @format.datetime?
+      @format.number_format = "\\$#,##0.00_);[RED]\"($\"#,##0.00\\)"
+      assert_equal false, @format.date?
     end
     def test_time?
       assert_equal false, @format.time?
@@ -52,6 +58,8 @@ module Spreadsheet
       assert_equal true, @format.time?
       @format.number_format = "hms"
       assert_equal true, @format.time?
+      @format.number_format = "\\$#,##0.00_);[RED]\"($\"#,##0.00\\)"
+      assert_equal false, @format.date?
     end
 		def test_borders?
 			assert_equal [:none, :none, :none, :none], @format.border


### PR DESCRIPTION
...sI ran into a situation where a spreadsheet had cells formatted with "[RED]" in the format. This matched the date_or_time? test and caused Roo to convert all the cells to DateTime. This fix is not the ultimate solution but does make this format tests a little more restrictive.
