### PR TITLE
Maintain gem version only in in lib/spreadsheet.rb

### DIFF
--- a/spreadsheet.gemspec
+++ b/spreadsheet.gemspec
@@ -1,6 +1,8 @@
+require File.join(File.dirname(__FILE__), 'lib', 'spreadsheet')
+
 spec = Gem::Specification.new do |s|
    s.name        = "spreadsheet"
-   s.version     = "0.9.5"
+   s.version     =  Spreadsheet::VERSION
    s.summary     = "The Spreadsheet Library is designed to read and write Spreadsheet Documents"
    s.description = "As of version 0.6.0, only Microsoft Excel compatible spreadsheets are supported"
    s.author      = "Masaomi Hatakeyama, Zeno R.R. Davatz"


### PR DESCRIPTION
It is always a bad idea having to change many places to release a new version.

This should simplify your life, Zeno!
