### PR TITLE
Reading cell and font colors done right

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 tags
 *.swp
+.idea/*
+.ruby-gemset
+.ruby-version

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source "https://rubygems.org"
 gem 'ruby-ole'
+gem 'rubyzip', '>= 1.0.0'
+gem 'nokogiri', '>= 1.4.4'
 
 group :development do
   gem 'hoe', '>= 3.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,12 +3,18 @@ GEM
   specs:
     hoe (3.7.1)
       rake (>= 0.8, < 11.0)
+    mini_portile (0.6.0)
+    nokogiri (1.6.2.1)
+      mini_portile (= 0.6.0)
     rake (10.1.0)
     ruby-ole (1.2.11.7)
+    rubyzip (1.1.4)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   hoe (>= 3.4)
+  nokogiri (>= 1.4.4)
   ruby-ole
+  rubyzip (>= 1.0.0)

--- a/lib/spreadsheet/excel/internals.rb
+++ b/lib/spreadsheet/excel/internals.rb
@@ -384,6 +384,33 @@ module Internals
     :obj          => 0x005d,                                                                                                      
     :drawing      => 0x00EC,                                                                                                      
     :txo          => 0x01B6,
+    :xfext        => 0x087D, # Microsoft Office Excel 97-2007 Binary File Format (.xls) Specification Page 289
+    :theme        => 0x0896, # Microsoft Office Excel 97-2007 Binary File Format (.xls) Specification Page 264
+    :continuefrt12 => 0x087F, #
+  }
+  XF_EXTENSION_TYPES = {
+      0  => :rgb_fg_color,        # Sets cell interior forecolor to RGB
+      1  => :rgb_bg_color,        # Sets cell interior backcolor to RGB
+      2  => :reserved,            # Reserved; not used
+      3  => :reserved,            # Reserved; not used
+      4  => :fg_color,            # Sets cell interior forecolor
+      5  => :bg_color,            # Sets cell interior backcolor
+      6  => :gradient_tint,       # Sets cell interior to a specified gradient
+      7  => :border_color_top,    # Sets specified cell border color
+      8  => :border_color_bottom, # Sets specified cell border color
+      9  => :border_color_left,   # Sets specified cell border color
+      10 => :border_color_right,  # Sets specified cell border color
+      11 => :border_color_diag,   # Sets specified cell border color
+      12 => :reserved,            # Reserved; not used
+      13 => :text_color,          # Sets cell text color
+      14 => :font_scheme,         # Set cell font to use specified font scheme
+      15 => :indent,              # Set cell indentation level ( indents > 15)
+  }
+  XF_EXTENSION_COLOR_TYPES = {
+      0 => :auto,    # Automatic foreground/background colors
+      1 => :indexed, # xclrValue = BIFF8 indexed palette color (icv)
+      2 => :rgb,     # xclrValue = RGB color
+      3 => :themed,  # xclrValue = Theme color index
   }
 =begin ## unknown opcodes
 0x00bf, 0x00c0, 0x00c1, 0x00e1, 0x00e2, 0x00eb, 0x01af, 0x01bc
@@ -452,6 +479,14 @@ module Internals
   end
   def opcode key
     OPCODES[key]
+  end
+  def rgb_hex rgb
+    # convert to hex and cut off unused last byte (2.5.4 RGB Colours)
+    color = rgb.to_s(16).split(//)
+    (8 - color.size).times { color = color.unshift('0') } # '80FF' -> '000080FF'
+    color = color.join[0..5]
+    #puts "fixed #{rgb.to_s(16)} to #{color}"
+    color
   end
 end
   end

--- a/lib/spreadsheet/font.rb
+++ b/lib/spreadsheet/font.rb
@@ -19,6 +19,7 @@ module Spreadsheet
     ##
     # Font color
     colors :color
+    attr_accessor :color_index
     ##
     # Font weight
     # Valid values: :normal, :bold or any positive Integer.
@@ -64,6 +65,7 @@ module Spreadsheet
     def initialize name, opts={}
       self.name = name
       @color = :text
+      @color_index = nil
       @previous_fast_key = nil
       @size = nil
       @weight = nil

--- a/lib/spreadsheet/format.rb
+++ b/lib/spreadsheet/format.rb
@@ -85,6 +85,8 @@ module Spreadsheet
          :justify     => :vjustify,
          :middle      => [:vcenter, :vcentre, :center, :centre]
     attr_accessor :font, :number_format, :name, :pattern, :used_merge
+    attr_accessor :pattern_fg_color_xf_index
+    attr_accessor :extension
     ##
     # Text rotation
     attr_reader :rotation
@@ -99,7 +101,9 @@ module Spreadsheet
       @right_color      = :black
       @diagonal_color   = :black
       @pattern_fg_color = :border
+      @pattern_fg_color_xf_index = nil
       @pattern_bg_color = :pattern_bg
+      @extension = {} # XFEXT: XF Extension (87Dh)
       @regexes = {
         :date         => Regexp.new(client("[YMD]", 'UTF-8')),
         :date_or_time => Regexp.new(client("[hmsYMD]", 'UTF-8')),

--- a/lib/spreadsheet/workbook.rb
+++ b/lib/spreadsheet/workbook.rb
@@ -12,13 +12,14 @@ module Spreadsheet
   #                   Row#default_format or Worksheet#default_format.
   class Workbook
     include Spreadsheet::Encodings
-    attr_reader :io, :worksheets, :formats, :fonts, :palette
+    attr_reader :io, :worksheets, :formats, :fonts, :palette, :theme
     attr_accessor :active_worksheet, :encoding, :default_format, :version
     def initialize io = nil, opts={:default_format => Format.new}
       @worksheets = []
       @io = io
       @fonts = []
       @palette = {}
+      @theme = {}
       @formats = []
       @formats_set = {}
       if @default_format = opts[:default_format]

--- a/spreadsheet.gemspec
+++ b/spreadsheet.gemspec
@@ -14,6 +14,8 @@ spec = Gem::Specification.new do |s|
    s.executables << "xlsopcodes"
 
    s.add_dependency "ruby-ole"
+   s.add_dependency 'rubyzip', '>= 1.0.0'
+   s.add_dependency 'nokogiri', '>= 1.4.4'
    s.add_development_dependency "hoe"
 
    s.homepage	 = "https://github.com/zdavatz/spreadsheet/"


### PR DESCRIPTION
Hi Zeno, I'm working on adding a possibility to the gem to read cell background and font colors exactly how Excel displays them on screen. I've smoked the specs and added readers for some additional data that needs to be extracted to implement this feature. The branch is not finished yet, because obviously what we want from the gem is to output real color values, like '#add3f7', and the code to interpret this additional data is yet to be added (it is ready but is now in an external module).

If you think it's worth adding it to the gem, please comment on my reader implementation, (so this isn't really a pull request).
