### PR TITLE
Fixing Excel::Worksheet#dimensions

### DIFF
--- a/lib/spreadsheet/excel/worksheet.rb
+++ b/lib/spreadsheet/excel/worksheet.rb
@@ -102,11 +102,11 @@ class Worksheet < Spreadsheet::Worksheet
     compact = @rows.compact
     first_rows = compact.collect do |row| row.first_used end.compact.min
     first_addrs = @row_addresses.compact.collect do |addr|
-      addr[:first_used] end.min
+      addr[:first_used] end.compact.min
     @dimensions[2] = [ first_rows, first_addrs ].compact.min || 0
     last_rows = compact.collect do |row| row.first_unused end.max
     last_addrs = @row_addresses.compact.collect do |addr|
-      addr[:first_unused] end.max
+      addr[:first_unused] end.compact.max
     @dimensions[3] = [last_rows, last_addrs].compact.max || 0
     @dimensions
   end


### PR DESCRIPTION
[This file](https://yadi.sk/i/RrJgBR8He9CB7) causes `ArgumentError: comparison of NilClass with 0 failed` when #dimensions is called on a worksheet.

How to reproduce:

```
require 'spreadsheet'
ss = Spreadsheet.open 'spreadsheet_dimensions_error.xls'
ss.worksheets.last.dimensions
```

Fix by [Kolmetoista](https://github.com/kolmetoista)