### PR TITLE
Update `ruby-ole` to `1.2.11.8`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     hoe (3.7.1)
       rake (>= 0.8, < 11.0)
     rake (10.1.0)
-    ruby-ole (1.2.11.7)
+    ruby-ole (1.2.11.8)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
`ruby-ole` <= `1.2.11.7` throws a duplicated key warning in Ruby 2.2.
This commit updates `ruby-ole` to `1.2.11.8`, which fixes this warning.

Related discussion: [aquasync/ruby-ole#15]

[aquasync/ruby-ole#15]: https://github.com/aquasync/ruby-ole/issues/15