### PR TITLE
add format for nubmer with out #

### DIFF
--- a/lib/spreadsheet/format.rb
+++ b/lib/spreadsheet/format.rb
@@ -105,7 +105,7 @@ module Spreadsheet
         :date_or_time => Regexp.new(client("[hmsYMD]", 'UTF-8')),
         :datetime     => Regexp.new(client("([YMD].*[HS])|([HS].*[YMD])", 'UTF-8')),
         :time         => Regexp.new(client("[hms]", 'UTF-8')),
-        :number       => Regexp.new(client("[\#]", 'UTF-8'))
+        :number       => Regexp.new(client("([\#]|0+)", 'UTF-8'))
       }
 
       # Temp code to prevent merged formats in non-merged cells.

--- a/spreadsheet.gemspec
+++ b/spreadsheet.gemspec
@@ -1,4 +1,7 @@
-require File.join(File.dirname(__FILE__), 'lib', 'spreadsheet')
+# require File.join(File.dirname(__FILE__), 'lib', 'spreadsheet')
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'spreadsheet'
 
 spec = Gem::Specification.new do |s|
    s.name        = "spreadsheet"

--- a/test/format.rb
+++ b/test/format.rb
@@ -21,6 +21,8 @@ module Spreadsheet
       assert_equal true, @format.date?
       @format.number_format = "\\$#,##0.00_);[RED]\"($\"#,##0.00\\)"
       assert_equal false, @format.date?
+      @format.number_format = "0.00;[RED]\\-0.00"
+      assert_equal false, @format.date?
     end
     def test_date_or_time?
       assert_equal false, @format.date_or_time?
@@ -31,7 +33,9 @@ module Spreadsheet
       @format.number_format = "hmsYMD"
       assert_equal true, @format.date_or_time?
       @format.number_format = "\\$#,##0.00_);[RED]\"($\"#,##0.00\\)"
-      assert_equal false, @format.date?
+      assert_equal false, @format.date_or_time?
+      @format.number_format = "0.00;[RED]\\-0.00)"
+      assert_equal false, @format.date_or_time?
     end
     def test_datetime?
       assert_equal false, @format.datetime?
@@ -44,7 +48,9 @@ module Spreadsheet
       @format.number_format = "HSYMD"
       assert_equal true, @format.datetime?
       @format.number_format = "\\$#,##0.00_);[RED]\"($\"#,##0.00\\)"
-      assert_equal false, @format.date?
+      assert_equal false, @format.datetime?
+      @format.number_format = "0.00;[RED]\\-0.00)"
+      assert_equal false, @format.datetime?
     end
     def test_time?
       assert_equal false, @format.time?
@@ -59,7 +65,9 @@ module Spreadsheet
       @format.number_format = "hms"
       assert_equal true, @format.time?
       @format.number_format = "\\$#,##0.00_);[RED]\"($\"#,##0.00\\)"
-      assert_equal false, @format.date?
+      assert_equal false, @format.time?
+      @format.number_format = "0.00;[RED]\\-0.00)"
+      assert_equal false, @format.time?
     end
 		def test_borders?
 			assert_equal [:none, :none, :none, :none], @format.border


### PR DESCRIPTION
I had a problem with read a file when some cells had format like "0.00;[RED]\\-0.00' - and this recognized as date.