### PR TITLE
Disregard locale indicators in number format

### DIFF
--- a/lib/spreadsheet/format.rb
+++ b/lib/spreadsheet/format.rb
@@ -105,7 +105,8 @@ module Spreadsheet
         :date_or_time => Regexp.new(client("[hmsYMD]", 'UTF-8')),
         :datetime     => Regexp.new(client("([YMD].*[HS])|([HS].*[YMD])", 'UTF-8')),
         :time         => Regexp.new(client("[hms]", 'UTF-8')),
-        :number       => Regexp.new(client("([\#]|0+)", 'UTF-8'))
+        :number       => Regexp.new(client("([\#]|0+)", 'UTF-8')),
+        :locale       => Regexp.new(client(/\A\[\$\-\d+\]/.to_s, 'UTF-8')),
       }
 
       # Temp code to prevent merged formats in non-merged cells.
@@ -183,27 +184,35 @@ module Spreadsheet
     ##
     # Is the cell formatted as a Date?
     def date?
-      !number? && !!@regexes[:date].match(@number_format.to_s)
+      !number? && matches_format?(:date)
     end
     ##
     # Is the cell formatted as a Date or Time?
     def date_or_time?
-      !number? && !!@regexes[:date_or_time].match(@number_format.to_s)
+      !number? && matches_format?(:date_or_time)
     end
     ##
     # Is the cell formatted as a DateTime?
     def datetime?
-      !number? && !!@regexes[:datetime].match(@number_format.to_s)
+      !number? && matches_format?(:datetime)
     end
     ##
     # Is the cell formatted as a Time?
     def time?
-      !number? && !!@regexes[:time].match(@number_format.to_s)
+      !number? && matches_format?(:time)
     end
     ##
     # Is the cell formatted as a number?
     def number?
-      !!@regexes[:number].match(@number_format.to_s)
+      matches_format?(:number)
+    end
+    ##
+    # Does the cell match a particular preset format?
+    def matches_format?(name)
+      # Excel number formats may optionally include a locale identifier like this:
+      #   [$-409]
+      format = @number_format.to_s.sub(@regexes[:locale], '')
+      !!@regexes[name].match(format)
     end
   end
 end

--- a/test/format.rb
+++ b/test/format.rb
@@ -19,6 +19,8 @@ module Spreadsheet
       assert_equal true, @format.date?
       @format.number_format = "YMD"
       assert_equal true, @format.date?
+      @format.number_format = "[$-409]YMD"
+      assert_equal true, @format.date?
       @format.number_format = "\\$#,##0.00_);[RED]\"($\"#,##0.00\\)"
       assert_equal false, @format.date?
       @format.number_format = "0.00;[RED]\\-0.00"
@@ -31,6 +33,8 @@ module Spreadsheet
       @format.number_format = "YMD"
       assert_equal true, @format.date_or_time?
       @format.number_format = "hmsYMD"
+      assert_equal true, @format.date_or_time?
+      @format.number_format = "[$-409]hmsYMD"
       assert_equal true, @format.date_or_time?
       @format.number_format = "\\$#,##0.00_);[RED]\"($\"#,##0.00\\)"
       assert_equal false, @format.date_or_time?
@@ -61,6 +65,8 @@ module Spreadsheet
       @format.number_format = "h"
       assert_equal true, @format.time?
       @format.number_format = "hm"
+      assert_equal true, @format.time?
+      @format.number_format = "[$-409]hms"
       assert_equal true, @format.time?
       @format.number_format = "hms"
       assert_equal true, @format.time?


### PR DESCRIPTION
We had a report of certain spreadsheets not being read correctly by our application. Investigation showed that depending on the date/time format, cells containing a date were sometimes being returned as fractional days.

We determined that the number format for these cells included the string "[$-409]" before the datetime formatting. Cells are checked to see if they are numbers before anything else, and since the presence of "0" causes the `:number` regex to match, the datetime checks never occur.

"[$-nnn]" is Excel formatting code that controls which locale is used to render the date. It's not relevant to determine the type of data in the field, so we are just removing it from the string before testing it with the regex.

As far as we can tell, this format was produced by Excel itself. Selecting Format -> Cells... -> Date and then a format in another locale will reliably generate the "[$-nnn]" code.