### PR TITLE
Also ignore locale indicators in number formats containing a letter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 tags
 *.swp
+.idea

--- a/lib/spreadsheet/format.rb
+++ b/lib/spreadsheet/format.rb
@@ -101,12 +101,12 @@ module Spreadsheet
       @pattern_fg_color = :border
       @pattern_bg_color = :pattern_bg
       @regexes = {
-        :date         => Regexp.new(client("[YMD]", 'UTF-8')),
-        :date_or_time => Regexp.new(client("[hmsYMD]", 'UTF-8')),
-        :datetime     => Regexp.new(client("([YMD].*[HS])|([HS].*[YMD])", 'UTF-8')),
-        :time         => Regexp.new(client("[hms]", 'UTF-8')),
-        :number       => Regexp.new(client("([\#]|0+)", 'UTF-8')),
-        :locale       => Regexp.new(client(/\A\[\$\-\D*\d+\]/.to_s, 'UTF-8')),
+        :date         => Regexp.new(client('[YMD]|(?:y|\bm{2,}\b|d)', 'UTF-8')),
+        :date_or_time => Regexp.new(client('[hmsYMD]', 'UTF-8')),
+        :datetime     => Regexp.new(client('(?:[YMD].*[HS])|(?:[HS].*[YMD])', 'UTF-8')),
+        :time         => Regexp.new(client('h|(?!m)m(?<!m)|s', 'UTF-8')),
+        :number       => Regexp.new(client('(?:[\#]|0+)', 'UTF-8')),
+        :locale       => Regexp.new(client('\A\[\$\-\h*\d+\]', 'UTF-8')),
       }
 
       # Temp code to prevent merged formats in non-merged cells.

--- a/lib/spreadsheet/format.rb
+++ b/lib/spreadsheet/format.rb
@@ -106,7 +106,7 @@ module Spreadsheet
         :datetime     => Regexp.new(client("([YMD].*[HS])|([HS].*[YMD])", 'UTF-8')),
         :time         => Regexp.new(client("[hms]", 'UTF-8')),
         :number       => Regexp.new(client("([\#]|0+)", 'UTF-8')),
-        :locale       => Regexp.new(client(/\A\[\$\-\d+\]/.to_s, 'UTF-8')),
+        :locale       => Regexp.new(client(/\A\[\$\-\D*\d+\]/.to_s, 'UTF-8')),
       }
 
       # Temp code to prevent merged formats in non-merged cells.

--- a/lib/spreadsheet/format.rb
+++ b/lib/spreadsheet/format.rb
@@ -101,10 +101,10 @@ module Spreadsheet
       @pattern_fg_color = :border
       @pattern_bg_color = :pattern_bg
       @regexes = {
-        :date         => Regexp.new(client('[YMD]|(?:y|\bmm+\b|d)', 'UTF-8')),
+        :date         => Regexp.new(client('[YMD]|(?:y|d|(?:[^m]|\A)mm+(?:[^m]|\z))', 'UTF-8')),
         :date_or_time => Regexp.new(client('[hmsYMD]', 'UTF-8')),
         :datetime     => Regexp.new(client('(?:[YMD].*[HS])|(?:[HS].*[YMD])', 'UTF-8')),
-        :time         => Regexp.new(client('h|(?:[^m]|^)m(?:[^m]|$)|s', 'UTF-8')),
+        :time         => Regexp.new(client('h|s|(?:[^m]|\A)m(?:[^m]|\z)', 'UTF-8')),
         :number       => Regexp.new(client('(?:[\#]|0+)', 'UTF-8')),
         :locale       => Regexp.new(client('\A\[\$\-\h*\d+\]', 'UTF-8')),
       }

--- a/lib/spreadsheet/format.rb
+++ b/lib/spreadsheet/format.rb
@@ -101,10 +101,10 @@ module Spreadsheet
       @pattern_fg_color = :border
       @pattern_bg_color = :pattern_bg
       @regexes = {
-        :date         => Regexp.new(client('[YMD]|(?:y|\bm{2,}\b|d)', 'UTF-8')),
+        :date         => Regexp.new(client('[YMD]|(?:y|\bmm+\b|d)', 'UTF-8')),
         :date_or_time => Regexp.new(client('[hmsYMD]', 'UTF-8')),
         :datetime     => Regexp.new(client('(?:[YMD].*[HS])|(?:[HS].*[YMD])', 'UTF-8')),
-        :time         => Regexp.new(client('h|(?!m)m(?<!m)|s', 'UTF-8')),
+        :time         => Regexp.new(client('h|(?:[^m]|^)m(?:[^m]|$)|s', 'UTF-8')),
         :number       => Regexp.new(client('(?:[\#]|0+)', 'UTF-8')),
         :locale       => Regexp.new(client('\A\[\$\-\h*\d+\]', 'UTF-8')),
       }

--- a/test/format.rb
+++ b/test/format.rb
@@ -38,6 +38,8 @@ module Spreadsheet
       assert_equal true, @format.date_or_time?
       @format.number_format = "[$-409]hmsYMD"
       assert_equal true, @format.date_or_time?
+      @format.number_format = "[$-F800]dddd\\,\\ mmmm\\ dd\\,\\ yyyy"
+      assert_equal true, @format.date_or_time?
       @format.number_format = "\\$#,##0.00_);[RED]\"($\"#,##0.00\\)"
       assert_equal false, @format.date_or_time?
       @format.number_format = "0.00;[RED]\\-0.00)"
@@ -57,6 +59,8 @@ module Spreadsheet
       assert_equal false, @format.datetime?
       @format.number_format = "0.00;[RED]\\-0.00)"
       assert_equal false, @format.datetime?
+      @format.number_format = "[$-F800]dddd\\,\\ mmmm\\ dd\\,\\ yyyy"
+      assert_equal false, @format.datetime?
     end
     def test_time?
       assert_equal false, @format.time?
@@ -70,6 +74,8 @@ module Spreadsheet
       assert_equal true, @format.time?
       @format.number_format = "[$-409]hms"
       assert_equal true, @format.time?
+      @format.number_format = "[$-F800]dddd\\,\\ mmmm\\ dd\\,\\ yyyy"
+      assert_equal false, @format.time?
       @format.number_format = "hms"
       assert_equal true, @format.time?
       @format.number_format = "\\$#,##0.00_);[RED]\"($\"#,##0.00\\)"

--- a/test/format.rb
+++ b/test/format.rb
@@ -21,6 +21,8 @@ module Spreadsheet
       assert_equal true, @format.date?
       @format.number_format = "[$-409]YMD"
       assert_equal true, @format.date?
+      @format.number_format = "[$-F800]dddd\\,\\ mmmm\\ dd\\,\\ yyyy"
+      assert_equal true, @format.date?
       @format.number_format = "\\$#,##0.00_);[RED]\"($\"#,##0.00\\)"
       assert_equal false, @format.date?
       @format.number_format = "0.00;[RED]\\-0.00"


### PR DESCRIPTION
Some locale indicators may contain a letter, like '[$-F800]'