### PR TITLE
Fixed Unknown Codepage 0x5212

### DIFF
--- a/lib/spreadsheet/excel/internals.rb
+++ b/lib/spreadsheet/excel/internals.rb
@@ -50,6 +50,7 @@ module Internals
     1258 => "WINDOWS-1258", #(Vietnamese)
     1361 => "WINDOWS-1361", #(Korean (Johab))
     10000 => "MACROMAN",
+    21010 => "UTF-16LE",
     32768 => "MACROMAN",
     32769 => "WINDOWS-1252", #(Latin I) (BIFF2-BIFF3)
   }


### PR DESCRIPTION
I got a error message - "Unknown Codepage 0x5212", when I opened an excel file.

The excel is created by JExcelAPI with 'Big5' encoding.

I found the file's codepage_id is 21010.

Then I solved it using "UTF-16LE" encoding.

Signed-off-by: ChouAndy <chouandy@ecoworkinc.com>