### PR TITLE
Fix issue with iconv on Ubuntu 12.04

### DIFF
--- a/lib/spreadsheet.rb
+++ b/lib/spreadsheet.rb
@@ -52,10 +52,12 @@ module Spreadsheet
   # different Encoding:
   # Spreadsheet.client_encoding = 'ISO-LATIN-1//TRANSLIT//IGNORE'
   @client_encoding = 'UTF-8'
+  @enc_translit = 'TRANSLIT'
+  @enc_ignore = 'IGNORE'
 
   class << self
 
-    attr_accessor :client_encoding
+    attr_accessor :client_encoding, :enc_translit, :enc_ignore
 
     ##
     # Parses a Spreadsheet Document and returns a Workbook object. At present,

--- a/lib/spreadsheet/encodings.rb
+++ b/lib/spreadsheet/encodings.rb
@@ -26,22 +26,27 @@ module Spreadsheet
     else
       require 'iconv'
       @@iconvs = {}
+
+      def build_output_encoding(to_encoding)
+        [to_encoding, Spreadsheet.enc_translit, Spreadsheet.enc_ignore].compact.join('//')
+      end
+
       def client string, internal='UTF-16LE'
         string = string.dup
         key = [Spreadsheet.client_encoding, internal]
         iconv = @@iconvs[key] ||= Iconv.new(Spreadsheet.client_encoding, internal)
         iconv.iconv string
       end
-      def internal string, client=Spreadsheet.client_encoding
+      def internal string, client=Spreadsheet.client_encoding, to_encoding = 'UTF-16LE'
         string = string.dup
-        key = ['UTF-16LE', client]
-        iconv = @@iconvs[key] ||= Iconv.new('UTF-16LE//TRANSLIT//IGNORE', client)
+        key = [to_encoding, client]
+        iconv = @@iconvs[key] ||= Iconv.new(build_output_encoding(to_encoding), client)
         iconv.iconv string
       end
-      def utf8 string, client=Spreadsheet.client_encoding
+      def utf8 string, client=Spreadsheet.client_encoding, to_encoding = 'UTF-8'
         string = string.dup
-        key = ['UTF-8', client]
-        iconv = @@iconvs[key] ||= Iconv.new('UTF-8//TRANSLIT//IGNORE', client)
+        key = [to_encoding, client]
+        iconv = @@iconvs[key] ||= Iconv.new(build_output_encoding(to_encoding), client)
         iconv.iconv string
       end
     end
@@ -55,3 +60,4 @@ module Spreadsheet
     end
   end
 end
+


### PR DESCRIPTION
This fix is related to a bug in the iconv implementation packaged with libc6 on Ubuntu 12.04.
The (known) ruby version affected is 1.8.7.

For some reasons, the encoding options ```//TRANSLIT//IGNORE``` seem to be improperly applied. When ```//TRANSLIT``` is specified, instead of rescuing errors related to ```//TRANSLIT``` and checking if the ```//IGNORE``` is set, the code simply crashes.

I would like to be able to disable ```//TRANSLIT``` for that specific use case and so I moved the encoding options to attribute accessors on the Spreadsheet module.