### PR TITLE
Avoid creating a class variable

### DIFF
--- a/lib/spreadsheet/excel/workbook.rb
+++ b/lib/spreadsheet/excel/workbook.rb
@@ -28,8 +28,7 @@ class Workbook < Spreadsheet::Workbook
   attr_accessor :bof, :ole
   attr_writer :date_base
   def Workbook.open io, opts = {}
-    @reader = Reader.new opts
-    @reader.read io
+    Reader.new(opts).read(io)    
   end
   def initialize *args
     super


### PR DESCRIPTION
That variable cannot be garbage collected and it retains a lot of memory.

Would be great if you can consider this change and made a new release of this gem.