### PR TITLE
Use codepage 1200 when writing UTF-16LE files

### DIFF
--- a/lib/spreadsheet/excel/internals.rb
+++ b/lib/spreadsheet/excel/internals.rb
@@ -54,7 +54,7 @@ module Internals
     32768 => "MACROMAN",
     32769 => "WINDOWS-1252", #(Latin I) (BIFF2-BIFF3)
   }
-  SEGAPEDOC = CODEPAGES.invert
+  SEGAPEDOC = CODEPAGES.reject { |k| k >= 21010 }.invert
   # color_codes according to http://support.softartisans.com/kbview_1205.aspx
   # synonyms are in comments when reverse lookup
   COLOR_CODES = {

--- a/lib/spreadsheet/excel/internals.rb
+++ b/lib/spreadsheet/excel/internals.rb
@@ -54,7 +54,7 @@ module Internals
     32768 => "MACROMAN",
     32769 => "WINDOWS-1252", #(Latin I) (BIFF2-BIFF3)
   }
-  SEGAPEDOC = CODEPAGES.reject { |k| k >= 21010 }.invert
+  SEGAPEDOC = CODEPAGES.reject { |k, _v| k >= 21010 }.invert
   # color_codes according to http://support.softartisans.com/kbview_1205.aspx
   # synonyms are in comments when reverse lookup
   COLOR_CODES = {


### PR DESCRIPTION
PR #161 created an issue (#189) where an invalid code page is used when writing the workbook using the default encoding UTF-16LE.  This PR will remove the invalid codes from the list used to look up code page identifiers by name so it returns the correct code page for UTF-16LE, MACROMAN, and WINDOWS-1252.