### PR TITLE
Suppresses assigned but unused var warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 sudo: false
 cache: bundler
 before_install:
-  - gem install bundler
+  - gem install bundler -v 1.17.3 --no-rdoc --no-ri
 bundler_args: --binstubs
 script: "bundle exec ruby test/suite.rb"
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 sudo: false
 cache: bundler
 before_install:
-  - gem install bundler -v 1.17.3 --no-rdoc --no-ri
+  - gem install bundler -v 1.17.3 --no-document
 bundler_args: --binstubs
 script: "bundle exec ruby test/suite.rb"
 rvm:

--- a/lib/spreadsheet/excel/reader.rb
+++ b/lib/spreadsheet/excel/reader.rb
@@ -399,10 +399,10 @@ class Reader
       end
       formula.value = value
     elsif rtype == 0
-      pos, op, len, work = get_next_chunk
+      pos, op, _len, work = get_next_chunk
       if op == :sharedfmla
         ## TODO: formula-support in 0.8.0
-        pos, op, len, work = get_next_chunk
+        pos, op, _len, work = get_next_chunk
       end
       if op == :string
         formula.value = client read_string(work, 2), @workbook.encoding


### PR DESCRIPTION
When running specs that depend on spreadsheet (or roo-xls) there is the
following warning: lib/spreadsheet/excel/reader.rb:402: warning:
assigned but unused variable - len.

[suppress-unused-var-warning-in-roo-xls]