### PR TITLE
Fixes remaining spec warnings and updates gemspec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ sudo: false
 cache: bundler
 before_install:
   - gem install bundler
+before_install:
+  - gem install bundler -v 1.17.3 --no-rdoc --no-ri
 bundler_args: --binstubs
 script: "bundle exec ruby test/suite.rb"
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,7 @@ language: ruby
 sudo: false
 cache: bundler
 before_install:
-  - gem install bundler
-before_install:
-  - gem install bundler -v 1.17.3 --no-rdoc --no-ri
+  - gem install bundler -v 1.17.3 --no-document
 bundler_args: --binstubs
 script: "bundle exec ruby test/suite.rb"
 rvm:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    hoe (3.14.2)
-      rake (>= 0.8, < 11.0)
+    hoe (3.17.1)
+      rake (>= 0.8, < 13.0)
     minitest (5.8.2)
     power_assert (0.2.4)
-    rake (10.4.2)
-    ruby-ole (1.2.11.8)
+    rake (10.5.0)
+    ruby-ole (1.2.12.1)
     test-unit (3.1.5)
       power_assert
 
@@ -20,4 +20,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   1.10.6
+   1.17.2

--- a/lib/spreadsheet/excel/reader.rb
+++ b/lib/spreadsheet/excel/reader.rb
@@ -399,10 +399,10 @@ class Reader
       end
       formula.value = value
     elsif rtype == 0
-      pos, op, len, work = get_next_chunk
+      pos, op, _len, work = get_next_chunk
       if op == :sharedfmla
         ## TODO: formula-support in 0.8.0
-        pos, op, len, work = get_next_chunk
+        pos, op, _len, work = get_next_chunk
       end
       if op == :string
         formula.value = client read_string(work, 2), @workbook.encoding
@@ -852,6 +852,7 @@ class Reader
     @detected_rows = {}
     @noteObjList = []
     @noteList = []
+    @noteObject = nil
     previous = nil
     while tuple = get_next_chunk
       pos, op, len, work = tuple

--- a/spreadsheet.gemspec
+++ b/spreadsheet.gemspec
@@ -3,7 +3,7 @@ lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'spreadsheet'
 
-spec = Gem::Specification.new do |spec|
+Gem::Specification.new do |spec|
    spec.name        = "spreadsheet"
    spec.version     =  Spreadsheet::VERSION
    spec.homepage    = "https://github.com/zdavatz/spreadsheet"
@@ -22,4 +22,3 @@ spec = Gem::Specification.new do |spec|
 
    spec.homepage    = 'https://github.com/zdavatz/spreadsheet/'
 end
-

--- a/test/integration.rb
+++ b/test/integration.rb
@@ -70,7 +70,7 @@ module Spreadsheet
     def test_missing_format
       path = File.join @data, 'test_missing_format.xls'
       assert_nothing_thrown do
-        workbook = Spreadsheet.open(path, "rb")
+        Spreadsheet.open(path, "rb")
       end
     end
     def test_version_excel97__excel2010__utf16
@@ -749,7 +749,7 @@ module Spreadsheet
       sheet1 = book.create_worksheet
       str1 = 'My Shared String'
       str2 = 'Another Shared String'
-      assert_equal 1, (str1.size + str2.size) % 2, 
+      assert_equal 1, (str1.size + str2.size) % 2,
         "str3 should start at an odd offset to test splitting of wide strings"
       str3 = '–––––––––– ' * 1000
       str4 = '1234567890 ' * 1000
@@ -1211,8 +1211,8 @@ module Spreadsheet
       book = Spreadsheet::Workbook.new
       sheet = book.create_worksheet
       (0..200).each { |i| sheet.row(i).push "ëçáéíóú" }
-      assert_nothing_raised do 
-        book.write StringIO.new("", "w+") 
+      assert_nothing_raised do
+        book.write StringIO.new("", "w+")
       end
     end
 
@@ -1257,7 +1257,7 @@ module Spreadsheet
       str1 = "Frozen String.".freeze
       sheet1[0,0] = str1
       sheet1.row(0).push str1
-      assert_nothing_raised do 
+      assert_nothing_raised do
         book.write path
       end
     end
@@ -1290,7 +1290,7 @@ module Spreadsheet
       sheet1 = book.create_worksheet
       (sheet1.row(0).format 0).border = :hair
       (sheet1.row(0).format 0).border_color = :brown
-      assert_nothing_raised do 
+      assert_nothing_raised do
         book.write path
       end
       book2 = Spreadsheet.open path
@@ -1391,7 +1391,7 @@ module Spreadsheet
       path = File.join @var, 'test_write_worksheet_visibility.xls'
       sheet1 = book.create_worksheet
       sheet1.visibility = :hidden
-      sheet2 = book.create_worksheet
+      _sheet2 = book.create_worksheet
       assert_nothing_raised do
         book.write path
       end


### PR DESCRIPTION
- Bumps gems
- Fixes remaining warnings in specs (see also https://github.com/zdavatz/spreadsheet/pull/226)

Before:
<img width="714" alt="screen shot 2019-01-24 at 20 29 25" src="https://user-images.githubusercontent.com/13652979/51725513-76bdd600-2017-11e9-8dc4-9929f49e066a.png">

After:
<img width="716" alt="screen shot 2019-01-24 at 20 28 34" src="https://user-images.githubusercontent.com/13652979/51725491-55f58080-2017-11e9-83a3-d6d650e36883.png">

[fixes-remaining-spec-warnings-and-updates-gemspec]