### PR TITLE
Add ability to chain methods to `Worksheet#each`

### DIFF
--- a/lib/spreadsheet/worksheet.rb
+++ b/lib/spreadsheet/worksheet.rb
@@ -153,9 +153,13 @@ module Spreadsheet
     # If the argument skip is given, #each iterates from that row until but
     # omitting the first unused Row, effectively skipping the first _skip_ Rows
     # from the top of the Worksheet.
-    def each skip=dimensions[0]
-      skip.upto(dimensions[1] - 1) do |idx|
-        yield row(idx)
+    def each(skip=dimensions[0], &block)
+      rows = skip.upto(dimensions[1] - 1).map { |index| row(index) }.to_enum
+
+      if block_given?
+        rows.each(&block)
+      else
+        rows
       end
     end
     def encoding # :nodoc:
@@ -314,7 +318,7 @@ module Spreadsheet
 
     def compact!
       recalculate_dimensions
-      
+
       # detect first non-nil non-empty row if given first row is empty or nil
       if row(@dimensions[0]).empty? || row(@dimensions[0]).compact.join('').empty?
         (@dimensions[0]...@dimensions[1]).each do |i|

--- a/test/worksheet.rb
+++ b/test/worksheet.rb
@@ -108,18 +108,35 @@ module Spreadsheet
       assert_equal 6, @book.formats.length
 
     end
-    
+
     def test_freeze_panel!
       assert_equal 0, @sheet.froze_top
       assert_equal 0, @sheet.froze_left
       assert_equal false, @sheet.has_frozen_panel?
-      
+
       @sheet.freeze!(2, 3)
       assert_equal 2, @sheet.froze_top
       assert_equal 3, @sheet.froze_left
       assert_equal true, @sheet.has_frozen_panel?
-      
+
     end
-    
+
+    def test_each_with_skip
+      @sheet[0, 0] = 'foo'
+      @sheet[1, 0] = 'bar'
+
+      assert_equal @sheet.each(1).count, 1
+      assert_equal @sheet.each(1).first[0], 'bar'
+    end
+
+    def test_each_with_index
+      @sheet[0, 0] = 'foo'
+      @sheet[1, 0] = 'bar'
+
+      @sheet.each.with_index do |row, index|
+        assert_equal row[0], @sheet[index, 0]
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Hey team,

Have been enjoying using this gem in my own projects - nice work!

One thing I've found to be limiting is the inability to treat `Worksheet#each` as you would `Enumerable#each`. For example you are unable to use `worksheet.each(1).with_index`. 

This PR adds in that functionality by returning an enumerable object when no block is provided immediately to `each`.

For example you can now do:
`worksheet.each(1).with_index do |row, index|`

It also respects the previous syntax and still allows:
`worksheet.each(1) do |row|`

I've written specs for both cases.

This is my first open source contribution so let me know if anything needs to be changed!