### PR TITLE
fixed FrozenError caused by frozen-string-literal

### DIFF
--- a/lib/spreadsheet/excel/reader/biff8.rb
+++ b/lib/spreadsheet/excel/reader/biff8.rb
@@ -196,7 +196,7 @@ module Biff8
   ##
   # Insert null-characters into a compressed UTF-16 string
   def wide string
-    data = ''
+    data = ''.dup
     string.each_byte do |byte| data << byte.chr << 0.chr end
     data
   end


### PR DESCRIPTION
Hi,

I got `FrozenError` error when I use spreadsheet gem with `--enable-frozen-string-literal` option.

```
   FrozenError:
       can't modify frozen String
     # C:/Users/ishitani/workspace/spreadsheet/lib/spreadsheet/excel/reader/biff8.rb:200:in `block in wide'
```

This PR is to fix the above error.
