### PR TITLE
Move declaration of VERSION to an individual file

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -49,6 +49,7 @@ lib/spreadsheet/link.rb
 lib/spreadsheet/note.rb
 lib/spreadsheet/noteObject.rb
 lib/spreadsheet/row.rb
+lib/spreadsheet/version.rb
 lib/spreadsheet/workbook.rb
 lib/spreadsheet/worksheet.rb
 lib/spreadsheet/writer.rb

--- a/lib/spreadsheet.rb
+++ b/lib/spreadsheet.rb
@@ -25,6 +25,7 @@
 #             8006 Zürich
 ###           Switzerland
 
+require 'spreadsheet/version'
 require 'spreadsheet/errors'
 
 require 'spreadsheet/excel/workbook'
@@ -43,10 +44,6 @@ require 'spreadsheet/excel/rgb'
 #  sheet = book.worksheet 0
 #  sheet.each do |row| puts row[0] end
 module Spreadsheet
-
-  ##
-  # The version of Spreadsheet you are using.
-  VERSION = '1.2.0'
 
   ##
   # Default client Encoding. Change this value if your application uses a

--- a/lib/spreadsheet/version.rb
+++ b/lib/spreadsheet/version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Spreadsheet
+  ##
+  # The version of Spreadsheet you are using.
+  VERSION = '1.2.0'
+end

--- a/spreadsheet.gemspec
+++ b/spreadsheet.gemspec
@@ -1,7 +1,7 @@
 # require File.join(File.dirname(__FILE__), 'lib', 'spreadsheet')
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'spreadsheet'
+require 'spreadsheet/version'
 
 Gem::Specification.new do |spec|
    spec.name        = "spreadsheet"

--- a/test/integration.rb
+++ b/test/integration.rb
@@ -36,7 +36,7 @@ module Spreadsheet
     end
     def teardown
       Spreadsheet.client_encoding = 'UTF-8'
-      FileUtils.rm_r @var
+      FileUtils.rm_rf @var
     end
     def test_copy__identical__file_paths
       path = File.join @data, 'test_copy.xls'


### PR DESCRIPTION
Hi,

To use my forked `spreadsheet` and `ruby-ole` gems, I add dependencies to my GEMFILE like below.

```ruby
if !ENV['USE_ORIGINAL_DEPENDENCIES']
  ['spreadsheet', 'rubyzip', 'ruby-ole'].each do |library|
    library_path = File.expand_path("../#{library}", __dir__)
    if Dir.exist?(library_path) && !ENV['USE_GITHUB_REPOSITORY']
      gem library, path: library_path
    else
      gem library, git: "https://github.com/taichi-ishitani/#{library}.git"
    end
  end
end
```

However, gem installation failed due to following error:
https://travis-ci.org/rggen/rggen-spreadsheet-loader/jobs/499367300#L904

```
[!] There was an error while loading `spreadsheet.gemspec`: cannot load such file -- ole/storage
Does it try to require a relative path? That's been removed in Ruby 1.9. Bundler cannot continue.
 #  from /home/travis/build/rggen/rggen-spreadsheet-loader/vendor/bundle/ruby/2.4.0/bundler/gems/spreadsheet-576264365474/spreadsheet.gemspec:4
 #  -------------------------------------------
 #  $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 >  require 'spreadsheet'
 #  
 #  -------------------------------------------
```

The spreadsheet.gemspec file loads spreadsheet.rb file to get `Spreadsheet::VERSION` constant.
The `ruby-ole` gem is loaded while loading spreadsheet.rb file and then this above error happened.

To fix above error, I created a new file named spreadsheet/version.rb and moved Spreadsheet::VERSION constant from spreadsheet.rb to spreadsheet/version.rb.
Also, I edited spreadsheet.gemspec to load spreadsheet/version.rb instead of spreadsheet.rb.
