### PR TITLE
Remove workaround for ruby-ole gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 tags
 *.swp
+/Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,11 +41,5 @@ matrix:
     - rvm: jruby-19mode
     - rvm: jruby-18mode
     - rvm: ree
-#notifications:
-#  email:
-#    recipients:
-#      - yasaka@ywesee.com
-#      - zdavatz@ywesee.com
-
 email:
-  false # temp
+  false

--- a/Gemfile
+++ b/Gemfile
@@ -1,16 +1,6 @@
 source "https://rubygems.org"
 
-if ENV['USE_LATEST_RUBY_OLE']
-  if Dir.exist?('../ruby-ole')
-    gem 'ruby-ole', :path => '../ruby-ole'
-  else
-    gem 'ruby-ole',
-      :git => 'https://github.com/taichi-ishitani/ruby-ole.git',
-      :branch => 'support_frozen_string_literal'
-  end
-else
-  gem 'ruby-ole'
-end
+gem 'ruby-ole', '>= 1.2.12.2'
 
 if RUBY_VERSION.to_f > 2.0
   gem 'test-unit'


### PR DESCRIPTION
Hi,

The latest `ruby-ole` gem including my PR (aquasync/ruby-ole#24) has been released.
Therefore, I removed workaround for installation of `ruby-ole` gem from `Gemfile` file.
