### PR TITLE
Fixes unrecognized date format

### DIFF
--- a/lib/spreadsheet/format.rb
+++ b/lib/spreadsheet/format.rb
@@ -101,12 +101,12 @@ module Spreadsheet
       @pattern_fg_color = :border
       @pattern_bg_color = :pattern_bg
       @regexes = {
-        :date         => Regexp.new(client("[YMD]", 'UTF-8')),
+        :date         => Regexp.new(client("[YMD]|d{2}|m{3}|y{2}", 'UTF-8')),
         :date_or_time => Regexp.new(client("[hmsYMD]", 'UTF-8')),
         :datetime     => Regexp.new(client("([YMD].*[HS])|([HS].*[YMD])", 'UTF-8')),
         :time         => Regexp.new(client("[hms]", 'UTF-8')),
         :number       => Regexp.new(client("([\#]|0+)", 'UTF-8')),
-        :locale       => Regexp.new(client(/\A\[\$\-\d+\]/.to_s, 'UTF-8')),
+        :locale       => Regexp.new(client(/\A\[\$\-\S+\]/.to_s, 'UTF-8')),
       }
 
       # Temp code to prevent merged formats in non-merged cells.

--- a/test/format.rb
+++ b/test/format.rb
@@ -25,6 +25,8 @@ module Spreadsheet
       assert_equal false, @format.date?
       @format.number_format = "0.00;[RED]\\-0.00"
       assert_equal false, @format.date?
+      @format.number_format = "[$-C0A]dd\\-mmm\\-yy"
+      assert_equal true, @format.date?
     end
     def test_date_or_time?
       assert_equal false, @format.date_or_time?


### PR DESCRIPTION
I have an excel using the format `[$-C0A]dd\\-mmm\\-yy` for dates (ex: `23-oct.-2019`), and the latest stable version recognizes that format as a number instead of a date. This PR tries to fix that issue.