### PR TITLE
add instance method "<<" to Spreadsheet::Worksheet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+dist: trusty
 sudo: false
 cache: bundler
 before_install:

--- a/lib/spreadsheet/worksheet.rb
+++ b/lib/spreadsheet/worksheet.rb
@@ -232,6 +232,9 @@ module Spreadsheet
       updated_from idx
       res
     end
+    def << cells=[]
+      insert_row last_row_index + 1, cells
+    end
     def inspect
       names = instance_variables
       names.delete '@rows'


### PR DESCRIPTION
Add instance method "<<" to Spreadsheet::Worksheet for duck typing with CSV library.