### PR TITLE
fix: Worksheet#<< fails to add data to the first row

### DIFF
--- a/lib/spreadsheet/worksheet.rb
+++ b/lib/spreadsheet/worksheet.rb
@@ -233,7 +233,7 @@ module Spreadsheet
       res
     end
     def << cells=[]
-      insert_row last_row_index + 1, cells
+      insert_row @rows.size, cells
     end
     def inspect
       names = instance_variables


### PR DESCRIPTION
related to PR #249

when sheet is empty, `last_row_index` return 0. `#<<` actually adds data to the second row. leaving the first row blank.

to reproduce:
```ruby
require 'spreadsheet'
wb = Spreadsheet::Workbook.new
sheet = wb.create_worksheet

sheet << ['A', 'B', 'C', 'D']
sheet << [1,2,3,4]

wb.write(File.expand_path('spreadsheet.xls', Dir.pwd))
```

![image](https://user-images.githubusercontent.com/548609/109382366-f7e4a700-791a-11eb-97e8-c95b9958d37a.png)
