### PR TITLE
Remove invalid worksheet characters

### DIFF
--- a/lib/spreadsheet/worksheet.rb
+++ b/lib/spreadsheet/worksheet.rb
@@ -28,6 +28,7 @@ module Spreadsheet
     include Spreadsheet::Encodings
     include Spreadsheet::Datatypes
     include Enumerable
+    INVALID_NAME_CHARACTERS = %r{[\\\/\*\?\:\[\]]}.freeze
     attr_accessor :name, :selected, :workbook, :password_hash
     attr_reader :rows, :columns, :merged_cells, :margins, :pagesetup
     attr_reader :froze_top, :froze_left
@@ -49,7 +50,7 @@ module Spreadsheet
         :right => 0.75,
         :bottom => 1
       }
-      @name = opts[:name] || 'Worksheet'
+      @name = (opts[:name] || 'Worksheet').gsub(INVALID_NAME_CHARACTERS, '_')
       @workbook = opts[:workbook]
       @rows = []
       @columns = []

--- a/lib/spreadsheet/worksheet.rb
+++ b/lib/spreadsheet/worksheet.rb
@@ -28,7 +28,6 @@ module Spreadsheet
     include Spreadsheet::Encodings
     include Spreadsheet::Datatypes
     include Enumerable
-    INVALID_NAME_CHARACTERS = %r{[\\\/\*\?\:\[\]]}.freeze
     attr_accessor :name, :selected, :workbook, :password_hash
     attr_reader :rows, :columns, :merged_cells, :margins, :pagesetup
     attr_reader :froze_top, :froze_left
@@ -50,7 +49,7 @@ module Spreadsheet
         :right => 0.75,
         :bottom => 1
       }
-      @name = (opts[:name] || 'Worksheet').gsub(INVALID_NAME_CHARACTERS, '_')
+      @name = sanitize_invalid_characters(opts[:name] || 'Worksheet')
       @workbook = opts[:workbook]
       @rows = []
       @columns = []
@@ -367,6 +366,9 @@ module Spreadsheet
     end
 
     private
+    def sanitize_invalid_characters(name) # :nodoc:
+      name.gsub(Regexp.new('[\\\/\*\?\:\[\]]'.encode(Spreadsheet.client_encoding)), '_')
+    end
     def index_of_first ary # :nodoc:
       return unless ary
       ary.index(ary.find do |elm| elm end)

--- a/test/worksheet.rb
+++ b/test/worksheet.rb
@@ -138,5 +138,10 @@ module Spreadsheet
       end
     end
 
+    def test_name
+      worksheet = Worksheet.new(name: '\a/b*c?d:e[f]')
+      assert_equal '_a_b_c_d_e_f_', worksheet.name
+    end
+
   end
 end


### PR DESCRIPTION
Based on http://www.excelcodex.com/2012/06/worksheets-naming-conventions/ (and reported in #70) this removes any invalid worksheet characters (`\ , / , * , ? , : , [ , ]`) from the name and replaces them with underscores.