### PR TITLE
Fix Ruby 3.3.0 warnings

### DIFF
--- a/spreadsheet.gemspec
+++ b/spreadsheet.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |spec|
    spec.test_file   = "test/suite.rb"
    spec.executables << "xlsopcodes"
 
+   spec.add_dependency "bigdecimal"
    spec.add_dependency "ruby-ole"
    spec.add_development_dependency "rake"
    spec.add_development_dependency "test-unit"


### PR DESCRIPTION
Running code that uses the spreadsheet gem with Ruby 3.3.0 causes the following warning to be shown

.../gems/spreadsheet-1.3.0/lib/spreadsheet/excel/writer/worksheet.rb:5: warning: bigdecimal was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add bigdecimal to your Gemfile or gemspec. Also contact author of spreadsheet-1.3.0 to add bigdecimal into its gemspec.

This behaviour is documented with the release of Ruby 3.3.0 https://rubyreferences.github.io/rubychanges/3.3.html#gems-that-are-warned-to-become-bundled-in-the-next-version