### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/spreadsheet

### DIFF
--- a/spreadsheet.gemspec
+++ b/spreadsheet.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |spec|
    spec.add_development_dependency "simplecov"
 
    spec.homepage    = 'https://github.com/zdavatz/spreadsheet/'
+   spec.metadata["changelog_uri"] = spec.homepage + "/blob/master/History.md"
 end


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/spreadsheet which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/