### PR TITLE
Add funding_uri to gemspec

### DIFF
--- a/spreadsheet.gemspec
+++ b/spreadsheet.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |spec|
 
    spec.homepage    = 'https://github.com/zdavatz/spreadsheet/'
    spec.metadata["changelog_uri"] = spec.homepage + "/blob/master/History.md"
+   spec.metadata["funding_uri"] = "https://github.com/sponsors/zdavatz"
 end


### PR DESCRIPTION
I noticed that the project already has a FUNDING.yml. This PR adds the `funding_uri` to your gemspec to help increase visibility using the `bundle fund` command in Bundler.