### PR TITLE
Remove trailing slash from spec.homepage

### DIFF
--- a/spreadsheet.gemspec
+++ b/spreadsheet.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
    spec.add_development_dependency "test-unit"
    spec.add_development_dependency "simplecov"
 
-   spec.homepage    = 'https://github.com/zdavatz/spreadsheet/'
+   spec.homepage    = 'https://github.com/zdavatz/spreadsheet'
    spec.metadata["changelog_uri"] = spec.homepage + "/blob/master/History.md"
    spec.metadata["funding_uri"] = "https://github.com/sponsors/zdavatz"
 end


### PR DESCRIPTION
At the moment `changelog_uri` is not displayed, as you can see on [rubygems.org](https://rubygems.org/gems/spreadsheet/versions/1.3.0?locale=en) or on dependabot updates.

<img width="917" alt="Screenshot 2024-11-20 at 09 51 47" src="https://github.com/user-attachments/assets/88747c79-c76b-4dcc-b604-58c8696903ad">

I suspect this is because the `changelog_uri` is `https://github.com/zdavatz/spreadsheet//blob/master/History.md` (note the double slash), and it might not pass the regex check.